### PR TITLE
Removed web app's dependencies install build step

### DIFF
--- a/web-app/Dockerfile.sandbox
+++ b/web-app/Dockerfile.sandbox
@@ -19,10 +19,5 @@ RUN mkdir -p ${APPLICATION_PATH}
 
 WORKDIR ${APPLICATION_PATH}
 
-# Inject package.json separate from the rest of
-# the codebase to make use of Docker's build cache.
-COPY package.json package.json
-RUN npm install
-
 # Drop to non-privileged user.
 USER $user_name


### PR DESCRIPTION
This does not make sense anymore, since we're bind mounting the application to the very directory we're installing the dependencies.